### PR TITLE
feat: Administrator dashboards

### DIFF
--- a/src/main/java/acme/forms/AdministratorDashboard.java
+++ b/src/main/java/acme/forms/AdministratorDashboard.java
@@ -1,0 +1,38 @@
+
+package acme.forms;
+
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdministratorDashboard {
+
+	// Serialisation identifier -----------------------------------------------
+
+	private static final long	serialVersionUID	= 1L;
+
+	// Attributes -------------------------------------------------------------
+
+	Map<String, Integer>		numberPrincipalsEachRole;
+
+	Double						noticesWithEmailAndLinkRatio;
+
+	Double						nonCriticalObjectivesRatio;
+
+	Double						averageValueRisks;
+	Double						minimumValueRisks;
+	Double						maximumValueRisks;
+	Double						deviationValueRisks;
+
+	Double						averageNumberClaimsLastTenWeeks;
+	Double						minimumNumberClaimsLastTenWeeks;
+	Double						maximumNumberClaimsLastTenWeeks;
+	Double						deviationNumberClaimsLastTenWeeks;
+	// Derived attributes -----------------------------------------------------
+
+	// Relationships ----------------------------------------------------------
+
+}


### PR DESCRIPTION
Added the administrator dashboard functionality. The ratio of critical or non-critical will be computed as the whole minus the ratio of one of them, since the attribute is mandatory.